### PR TITLE
Bugfix: Check for empty countInvalidList in readMethylSigData

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: methylSig
 Type: Package
 Title: a whole genome DNA methylation analysis pipeline
-Version: 0.4.1
-Date: 2015-12-17
+Version: 0.4.2
+Date: 2016-04-20
 Author: Yongseok Park
 Maintainer: Who to complain to <yongpark@pitt.edu>
 Description: MethylSig is a method for testing for differentially methylated
@@ -28,6 +28,6 @@ Suggests:
     testthat,
     knitr,
     rmarkdown
-Packaged: 2015-12-17; rcavalca
+Packaged: 2016-04-20; rcavalca
 VignetteBuilder: knitr
 RoxygenNote: 5.0.1

--- a/R/read.R
+++ b/R/read.R
@@ -172,16 +172,21 @@ methylSigReadData = function(fileList,
           ((coverage[, fileIndex] != 0) & (coverage[, fileIndex] < minCount)) |
           ((coverage[, fileIndex] != 0) & (coverage[, fileIndex] > maxCount)) ) ) )
       }
-    
-      uniqueLoc = uniqueLoc[-countInvalidList]
-      strand = strand[-countInvalidList]
-      coverage = coverage[-countInvalidList, ]
-      numCs = numCs[-countInvalidList, ]
-      numTs = numTs[-countInvalidList, ]
 
-      message(sprintf('Sites > maxCount or < minCount: %s / %s = %s',
-        length(countInvalidList), nrow(coverage) + length(countInvalidList),
-        signif( length(countInvalidList) / (nrow(coverage) + length(countInvalidList)) , 3)))
+	# For simulated data you could have nothing in the countInvalidList
+	if(length(countInvalidList) > 0) {
+		uniqueLoc = uniqueLoc[-countInvalidList]
+		strand = strand[-countInvalidList]
+		coverage = coverage[-countInvalidList, ]
+		numCs = numCs[-countInvalidList, ]
+		numTs = numTs[-countInvalidList, ]
+
+		message(sprintf('Sites > maxCount or < minCount: %s / %s = %s',
+			length(countInvalidList), nrow(coverage) + length(countInvalidList),
+			signif( length(countInvalidList) / (nrow(coverage) + length(countInvalidList)) , 3)))
+    } else {
+		message('Sites > maxCount or < minCount = 0')
+	}
 
 #    strand = as.factor(strand)
 #    levels(strand) = list("+"="1","-"="2","*"="3")


### PR DESCRIPTION
* In running simulated data from the [metilene](http://www.bioinf.uni-leipzig.de/Software/metilene/) manuscript I discovered
that methylSigReadData fails when there are no sites > maxCount or <
minCount.